### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(function() {
   function buildHTML(message) {
     if (message.image) {
       var html = 
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
             <div class="upper-message">
               <div class="upper-message__user-name">
                 ${message.user_name}
@@ -22,7 +22,7 @@ $(function() {
        return html;  
     } else {
       var html = 
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
           <div class="upper-message">
             <div class="upper-message__user-name">
               ${message.user_name}
@@ -52,18 +52,44 @@ $('#new_message').on('submit', function(e) {
     dataType: 'json',
     processData: false,
     contentType: false
+  })
+  .done(function(data) {  
+    var html = buildHTML(data);
+    $('.messages').append(html);
+    $('form')[0].reset();
+    $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
+  })
+    .fail(function () {
+      alert("error");
     })
-    .done(function(data) {  
-      var html = buildHTML(data);
-      $('.messages').append(html);
-      $('form')[0].reset();
-      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
+    .always(function (data) {
+      $('.form__submit').prop('disabled', false);
+    })
+})
+
+  var reloadMessages = function () { 
+    if (window.location.href.match(/\/groups\/\d+\/messages/)) {
+      var last_message_id = $('.message:last').data("message-id");
+      $.ajax({
+        url: "api/messages",
+        type: 'get',
+        dataType: 'json',
+        data: {id: last_message_id}
+      })
+      .done(function (messages) {
+        if (messages.length !== 0) {
+          var insertHTML = '';
+          $.each(messages, function(i, message) {
+            insertHTML += buildHTML(message)
+          });
+          $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
+        }
       })
       .fail(function () {
-        alert("error");
-      })
-      .always(function (data) {
-        $('.form__submit').prop('disabled', false);
-      })
-  });
+        alert('error');
+      });
+    }
+  };
+  setInterval(reloadMessages, 7000);
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = @group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
＃What
チャット画面で自動更新できるようにする
javascriptを使ってブラウザに秒で更新できる設定、リクエストしてDBに保存された最新のメッセージのidをJSON型でレスポンスする

＃Why
メッセージが自動でブラウザに反映されるようなツールにするため
ユーザーが快適にLineなどのチャットツールのよな機能を実装

[![Image from Gyazo](https://i.gyazo.com/c0dd41b92a0034106981b8d8b59c2f61.gif)](https://gyazo.com/c0dd41b92a0034106981b8d8b59c2f61)

[![Image from Gyazo](https://i.gyazo.com/b985b54554fa5f8c218bb47806430590.gif)](https://gyazo.com/b985b54554fa5f8c218bb47806430590)